### PR TITLE
ClearGL & JOML tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,17 @@
 			<version>44.0.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>net.clearvolume</groupId>
+			<artifactId>cleargl</artifactId>
+			<version>2.1.1</version>
+		</dependency>
 
+		<dependency>
+			<groupId>org.joml</groupId>
+			<artifactId>joml</artifactId>
+			<version>1.9.6</version>
+		</dependency>
 
 		<!-- Test dependencies -->
 		<dependency>

--- a/src/test/java/net/imglib2/matrix/shootout/cleargl/ClearGLVec3dAddTest.java
+++ b/src/test/java/net/imglib2/matrix/shootout/cleargl/ClearGLVec3dAddTest.java
@@ -1,0 +1,35 @@
+package net.imglib2.matrix.shootout.cleargl;
+
+import cleargl.GLVector;
+import net.imglib2.matrix.shootout.AbstractVec3fAddTest;
+import net.imglib2.matrix.shootout.Vec3fBuffer;
+
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+
+/**
+ * Float 3D vector addition test using ClearGL's GLVector
+ *
+ * @author Ulrik Günther <hello@ulrik.is>
+ */
+public class ClearGLVec3dAddTest extends AbstractVec3fAddTest {
+  @Override
+  public void addAsVec3(Vec3fBuffer bufA, Vec3fBuffer bufB, Vec3fBuffer bufC) {
+    final int size = bufA.getFloats().remaining()/3;
+    final FloatBuffer bufferA = bufA.getFloats();
+    final FloatBuffer bufferB = bufB.getFloats();
+    final ByteBuffer bufferC = bufC.getBytes();
+
+    for(int i = 0; i < size; i++) {
+      final GLVector a = new GLVector(0.0f, 0.0f, 0.0f);
+      final GLVector b = new GLVector(0.0f, 0.0f, 0.0f);
+      final GLVector c = new GLVector(0.0f, 0.0f, 0.0f);
+
+      bufferA.get(a.toFloatArray(), 0, 3);
+      bufferB.get(b.toFloatArray(), 0, 3);
+
+      c.plusAssign(a.plus(b));
+      c.put(bufferC);
+    }
+  }
+}

--- a/src/test/java/net/imglib2/matrix/shootout/joml/JOMLVec3dAddTest.java
+++ b/src/test/java/net/imglib2/matrix/shootout/joml/JOMLVec3dAddTest.java
@@ -1,0 +1,34 @@
+package net.imglib2.matrix.shootout.joml;
+
+import net.imglib2.matrix.shootout.AbstractVec3dAddTest;
+import net.imglib2.matrix.shootout.Vec3dBuffer;
+import org.joml.Vector3d;
+
+import java.nio.DoubleBuffer;
+
+/**
+ * Double 3D vector addition test using JOML's Vector3d
+ *
+ * @author Ulrik Günther <hello@ulrik.is>
+ */
+public class JOMLVec3dAddTest extends AbstractVec3dAddTest {
+  @Override
+  public void addAsVec3(Vec3dBuffer bufA, Vec3dBuffer bufB, Vec3dBuffer bufC) {
+    final int size = bufA.getDoubles().remaining()/3;
+
+    final DoubleBuffer bufferA = bufA.getDoubles();
+    final DoubleBuffer bufferB = bufB.getDoubles();
+    final DoubleBuffer bufferC = bufC.getDoubles();
+
+    for(int i = 0; i < size; i++) {
+      final Vector3d a = new Vector3d().set(bufferA);
+      final Vector3d b = new Vector3d().set(bufferB);
+
+      new Vector3d().set(a.add(b)).get(bufferC);
+
+      bufferA.position(bufferA.position()+3);
+      bufferB.position(bufferB.position()+3);
+      bufferC.position(bufferC.position()+3);
+    }
+  }
+}

--- a/src/test/java/net/imglib2/matrix/shootout/joml/JOMLVec3fAddTest.java
+++ b/src/test/java/net/imglib2/matrix/shootout/joml/JOMLVec3fAddTest.java
@@ -1,0 +1,34 @@
+package net.imglib2.matrix.shootout.joml;
+
+import net.imglib2.matrix.shootout.AbstractVec3fAddTest;
+import net.imglib2.matrix.shootout.Vec3fBuffer;
+import org.joml.Vector3f;
+
+import java.nio.FloatBuffer;
+
+/**
+ * Float 3D vector addition test using JOML's Vector3f
+ *
+ * @author Ulrik Günther <hello@ulrik.is>
+ */
+public class JOMLVec3fAddTest extends AbstractVec3fAddTest {
+  @Override
+  public void addAsVec3(Vec3fBuffer bufA, Vec3fBuffer bufB, Vec3fBuffer bufC) {
+    final int size = bufA.getFloats().remaining()/3;
+
+    final FloatBuffer bufferA = bufA.getFloats();
+    final FloatBuffer bufferB = bufB.getFloats();
+    final FloatBuffer bufferC = bufC.getFloats();
+
+    for(int i = 0; i < size; i++) {
+      final Vector3f a = new Vector3f().set(bufferA);
+      final Vector3f b = new Vector3f().set(bufferB);
+
+      new Vector3f().set(a.add(b)).get(bufferC);
+
+      bufferA.position(bufferA.position()+3);
+      bufferB.position(bufferB.position()+3);
+      bufferC.position(bufferC.position()+3);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds:
* Vec3f tests for ClearGL and JOML
* Vec3d test for JOML, as ClearGL supports only floats
