### PR TITLE
Use absolute/indexed Vector3d.get/put methods in JOML

### DIFF
--- a/src/test/java/net/imglib2/matrix/shootout/JOMLVec3dAddBenchmark.java
+++ b/src/test/java/net/imglib2/matrix/shootout/JOMLVec3dAddBenchmark.java
@@ -48,21 +48,16 @@ public class JOMLVec3dAddBenchmark
 
 	public Vector3d fromBuffer( DoubleBuffer buf, int pos )
 	{
-		buf.position(pos * 3);
-		return new Vector3d().set(buf);
+		return new Vector3d().set(pos * 3, buf);
 	}
 	public void toBuffer( Vector3d v, DoubleBuffer buf, int pos )
 	{
-		buf.position(pos * 3);
-		v.get(buf);
+		v.get(pos * 3, buf);
 	}
 
 	@Benchmark
 	public void benchmark()
 	{
-		bufferA.rewind();
-		bufferB.rewind();
-		bufferC.rewind();
 		for(int i = 0; i < size; i++) {
 			final Vector3d a = fromBuffer( bufferA, i );
 			final Vector3d b = fromBuffer( bufferB, i );

--- a/src/test/java/net/imglib2/matrix/shootout/joml/JOMLVec3dAddTest.java
+++ b/src/test/java/net/imglib2/matrix/shootout/joml/JOMLVec3dAddTest.java
@@ -21,14 +21,10 @@ public class JOMLVec3dAddTest extends AbstractVec3dAddTest {
     final DoubleBuffer bufferC = bufC.getDoubles();
 
     for(int i = 0; i < size; i++) {
-      final Vector3d a = new Vector3d().set(bufferA);
-      final Vector3d b = new Vector3d().set(bufferB);
+      final Vector3d a = new Vector3d().set(i*3, bufferA);
+      final Vector3d b = new Vector3d().set(i*3, bufferB);
 
-      new Vector3d().set(a.add(b)).get(bufferC);
-
-      bufferA.position(bufferA.position()+3);
-      bufferB.position(bufferB.position()+3);
-      bufferC.position(bufferC.position()+3);
+      new Vector3d().set(a.add(b)).get(i*3, bufferC);
     }
   }
 }

--- a/src/test/java/net/imglib2/matrix/shootout/joml/JOMLVec3fAddTest.java
+++ b/src/test/java/net/imglib2/matrix/shootout/joml/JOMLVec3fAddTest.java
@@ -21,14 +21,10 @@ public class JOMLVec3fAddTest extends AbstractVec3fAddTest {
     final FloatBuffer bufferC = bufC.getFloats();
 
     for(int i = 0; i < size; i++) {
-      final Vector3f a = new Vector3f().set(bufferA);
-      final Vector3f b = new Vector3f().set(bufferB);
+      final Vector3f a = new Vector3f().set(i*3, bufferA);
+      final Vector3f b = new Vector3f().set(i*3, bufferB);
 
-      new Vector3f().set(a.add(b)).get(bufferC);
-
-      bufferA.position(bufferA.position()+3);
-      bufferB.position(bufferB.position()+3);
-      bufferC.position(bufferC.position()+3);
+      new Vector3f().set(a.add(b)).get(i*3, bufferC);
     }
   }
 }


### PR DESCRIPTION
JOML provides indexed/absolute get/put methods in addition to the relative methods for NIO buffers, to avoid having to alter the buffer's position when writing/reading large numbers of objects to/from buffers.